### PR TITLE
Update path to model and ignore file in input_model folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+input_model/

--- a/norne/config/assisted_history_matching.yml
+++ b/norne/config/assisted_history_matching.yml
@@ -10,7 +10,7 @@ flownet:
     - disgas
     - water
   pvt:
-    rsvd: ./examples/norne_static/rsvd.csv
+    rsvd: rsvd.csv
   cell_length: 100
   additional_flow_nodes: 100
   additional_node_candidates: 1000

--- a/norne/config/assisted_history_matching.yml
+++ b/norne/config/assisted_history_matching.yml
@@ -2,7 +2,7 @@ name: Norne
 
 flownet:
   data_source:
-    input_case: ../tests/data/norne/NORNE_ATW2013
+    input_case: ../input_model/norne/NORNE_ATW2013
   phases:
     - oil
     - gas

--- a/norne/config/assisted_history_matching.yml
+++ b/norne/config/assisted_history_matching.yml
@@ -11,7 +11,7 @@ flownet:
     - disgas
     - water
   pvt:
-    rsvd: rsvd.csv
+    rsvd: norne_static/rsvd.csv
   cell_length: 100
   additional_flow_nodes: 100
   additional_node_candidates: 1000


### PR DESCRIPTION
This makes sure that when you just extract the norne model in-place and you run the config - it just works right away.

The extracted files are ignored as any directory called `input_model` is ignored. This off course means that if you add a new model you have to forcefully add the tar.gz as it is ignored by default in the input_folder.