### PR TITLE
Adding well control modes in history for Norne

### DIFF
--- a/norne/config/assisted_history_matching.yml
+++ b/norne/config/assisted_history_matching.yml
@@ -33,6 +33,8 @@ flownet:
   training_set_end_date: 2005-01-31
   fault_tolerance: 0.0001
   max_distance_fraction: 0.10
+  prod_control_mode: RESV
+  inj_control_mode: RATE
 
 ert:
   static_include_files: ./norne_static


### PR DESCRIPTION
Adding prod_control_mode (record 3 in WCONHIST) and inj_control_mode (record 12 in WCONINJH) to the Norne case.