### PR TITLE
Add kriging to Norne config

### DIFF
--- a/norne/ci_config/assisted_history_matching.yml
+++ b/norne/ci_config/assisted_history_matching.yml
@@ -6,6 +6,9 @@ flownet:
   additional_flow_nodes: 2
   additional_node_candidates: 100
   max_distance_fraction: 0.05
+  constraining:
+    kriging:
+      enabled: true
 
 ert:
   realizations:

--- a/norne/config/assisted_history_matching.yml
+++ b/norne/config/assisted_history_matching.yml
@@ -15,6 +15,21 @@ flownet:
           rel_error: 0.1
           min_error: 100000
     concave_hull: true
+  constraining:
+    kriging:
+      enabled: false
+      n: 20
+      n_lags: 6
+      anisotropy_scaling_z: 10
+      variogram_model: spherical
+      permeability_variogram_parameters:
+        sill: 0.75
+        range: 1000
+        nugget: 0
+      porosity_variogram_parameters:
+        sill: 0.05
+        range: 1000
+        nugget: 0
   phases:
     - oil
     - gas

--- a/norne/config/assisted_history_matching.yml
+++ b/norne/config/assisted_history_matching.yml
@@ -14,6 +14,7 @@ flownet:
         WGPR:
           rel_error: 0.1
           min_error: 100000
+      well_logs: true
     concave_hull: true
   constraining:
     kriging:


### PR DESCRIPTION
This PR adds kriging to the Norne config file:

- The Norne config will get kriging config with arbitrary values - to show users how to use it. Kriging is disabled by default.
- The Norne CI config will override the kriging and set it to **enabled**.